### PR TITLE
feat: scripts - ddcutil script to handle brightness control for exterrnal monitors

### DIFF
--- a/Configs/.local/share/bin/extbrightnesscontrol.sh
+++ b/Configs/.local/share/bin/extbrightnesscontrol.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env sh
+
+ScrDir=`dirname "$(realpath "$0")"`
+source $ScrDir/globalcontrol.sh
+
+monitorInfo=$( ddcutil detect )
+monitors=($( echo "$monitorInfo" | grep "I2C bus:" | awk -F ': ' '{print $2}' ))
+model=$( echo "$monitorInfo" | grep "Model:" | awk -F ': ' '{print $2}' | head -n 1 | xargs )
+
+function print_error
+{
+cat << "EOF"
+    ./brightnesscontrol.sh <action>
+    ...valid actions are...
+        i -- <i>ncrease  brightness [+5%]
+        d -- <d>ecrease  brightness [-5%]
+        s -- <s>et VALUE brightness [VALUE%]
+        g -- <g>et       brightness
+EOF
+}
+
+function get_brightness {
+    ddcutil getvcp 10 | awk -F 'current value = ' '{print $2}' | grep -o '[0-9]\+' | head -n 1
+}
+
+function send_notification {
+    brightness=$(get_brightness)
+    angle=$(((($brightness + 2) / 5) * 5))
+    ico="$HOME/.config/dunst/icons/vol/vol-${angle}.svg"
+    
+    notify-send -a "t2" -r 91190 -t 800 -i "${ico}" "Brightness ${brightness}" "${model}"
+}
+
+function set_brightness {
+    for v in "${monitors[@]}" ; do
+        bus=$( echo $v | awk -F '-' '{print $2}' )
+        
+        case $1 in
+        i)
+            ddcutil setvcp 10 + $2 --bus=$bus
+            ;;
+        d)
+            ddcutil setvcp 10 - $2 --bus=$bus
+            ;;
+        *)
+            ddcutil setvcp 10 $2 --bus=$bus
+            ;;
+        esac
+    done
+}
+
+case $1 in
+i)
+    if [[ $(get_brightness) -lt 10 ]] ; then
+        # increase the brightness by 1% if less than 10%
+        set_brightness i 1
+    else
+        # increase the brightness by 5% otherwise
+        set_brightness i 5
+    fi
+    send_notification ;;
+d)
+    if [[ $(get_brightness) -le 2 ]] ; then
+        # avoid 0% brightness
+        set_brightness s 2
+    elif [[ $(get_brightness) -le 10 ]] ; then
+        # decrease the brightness by 1% if less than 10%
+        set_brightness d 1
+    else
+        # decrease the brightness by 5% otherwise
+        set_brightness d 5
+    fi
+    send_notification ;;
+s)
+    if [[ $2 -le 2 ]] ; then
+        # avoid 0% brightness
+        set_brightness s 2
+    else
+        set_brightness s $2
+    fi
+    send_notification ;;
+g)
+    send_notification ;;
+*)
+    print_error ;;
+esac


### PR DESCRIPTION
A new script based on the default brightnesscontrol.sh but using **ddcutil** to control the brightness of **external monitors**.

The main issue is : DDC/CI protocol is **slow**

# Pull Request

## Description

- This script tries to achieve what the original brightnesscontrol script does with brightnessctl but for external monitors
- As I use 3 external monitors, I lacked a utility to easily change brightness. So here it is
- Dependencies: **ddcutil** only
- [Related issue](https://github.com/prasanthrangan/hyprdots/issues/1543)

## Type of change

Please put an `x` in the boxes that apply:

- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [x] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] **Documentation update** (non-breaking change; modified files are limited to the documentations)
- [ ] **Technical debt** (a code change that does not fix a bug or add a feature but makes something clearer for devs)
- [ ] **Other** (provide details below)

## Checklist

Please put an `x` in the boxes that apply:

- [x] I have read the [CONTRIBUTING](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My commit message follows the [commit guidelines](https://github.com/prasanthrangan/hyprdots/blob/main/CONTRIBUTING.md#git-commit-messages).
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added a changelog entry.
- [x] I have added necessary comments/documentation to my code.
- [ ] I have added tests to cover my changes.
- [x] I have tested my code locally and it works as expected.
- [x] All new and existing tests passed.

## Screenshots

![screenshot_20240822_17h55m26s](https://github.com/user-attachments/assets/15cbcb1b-0678-40ee-9a7d-0b385e57946e)


## Additional context

